### PR TITLE
More accurate calibration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ install(DIRECTORY launch config
 install (PROGRAMS 
   scripts/calibration_aruco_publisher.py
   scripts/follow_aruco_marker.py
+  scripts/handeye_publisher.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/launch/calibrate.launch.py
+++ b/launch/calibrate.launch.py
@@ -32,13 +32,6 @@ def generate_launch_description():
                                   executable='aruco_node',
                                   parameters=[aruco_params])
 
-    calibration_aruco_publisher = Node(
-        package="ar4_hand_eye_calibration",
-        executable="calibration_aruco_publisher.py",
-        name="calibration_aruco_publisher",
-        output="screen",
-    )
-
     calibration_args = {
         "name": "ar4_calibration",
         "calibration_type": "eye_on_base",
@@ -47,6 +40,18 @@ def generate_launch_description():
         "tracking_base_frame": "camera_color_optical_frame",
         "tracking_marker_frame": "calibration_aruco",
     }
+
+    calibration_aruco_publisher = Node(
+        package="ar4_hand_eye_calibration",
+        executable="calibration_aruco_publisher.py",
+        name="calibration_aruco_publisher",
+        output="screen",
+        parameters=[{
+            "tracking_base_frame": calibration_args["tracking_base_frame"],
+            "tracking_marker_frame": calibration_args["tracking_marker_frame"],
+            "marker_id": 1
+        }],
+    )
 
     easy_handeye2 = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([

--- a/launch/calibrate.launch.py
+++ b/launch/calibrate.launch.py
@@ -44,7 +44,7 @@ def generate_launch_description():
         "calibration_type": "eye_on_base",
         "robot_base_frame": "base_link",
         "robot_effector_frame": "ee_link",
-        "tracking_base_frame": "camera_color_frame",
+        "tracking_base_frame": "camera_color_optical_frame",
         "tracking_marker_frame": "calibration_aruco",
     }
 

--- a/launch/validate.launch.py
+++ b/launch/validate.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
         executable="handeye_publisher.py",
         name="handeye_publisher",
         parameters=[{
-            "name": "ar4_calibration"
+            "calibration_name": "ar4_calibration"
         }],
     )
 

--- a/launch/validate.launch.py
+++ b/launch/validate.launch.py
@@ -34,7 +34,8 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([
             os.path.join(get_package_share_directory("realsense2_camera"),
                          "launch", "rs_launch.py")
-        ]))
+        ])
+    )
 
     aruco_params = os.path.join(get_package_share_directory("ar4_hand_eye_calibration"),
                                 "config", "aruco_parameters.yaml")
@@ -42,12 +43,14 @@ def generate_launch_description():
                                   executable='aruco_node',
                                   parameters=[aruco_params])
 
-    calibration_tf_publisher = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([
-            os.path.join(get_package_share_directory("easy_handeye2"),
-                         "launch", "publish.launch.py")
-        ]),
-        launch_arguments={"name": "ar4_calibration"}.items())
+    hand_eye_tf_publisher = Node(
+        package="ar4_hand_eye_calibration",
+        executable="handeye_publisher.py",
+        name="handeye_publisher",
+        parameters=[{
+            "name": "ar4_calibration"
+        }],
+    )
 
     robot_description_content = Command([
         PathJoinSubstitution([FindExecutable(name="xacro")]),
@@ -167,6 +170,7 @@ def generate_launch_description():
                                          launch_arguments=ar_moveit_args)
 
     return LaunchDescription([
-        ar_model_arg, realsense, aruco_recognition_node,
-        calibration_tf_publisher, follow_aruco_node, ar_moveit
+        ar_model_arg, realsense, hand_eye_tf_publisher, 
+        aruco_recognition_node, follow_aruco_node, 
+        ar_moveit
     ])

--- a/package.xml
+++ b/package.xml
@@ -21,9 +21,9 @@
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>moveit_py</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-transforms3d</exec_depend>
   <exec_depend>ros2_aruco</exec_depend>
-  <exec_depend>tf_transformations</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/scripts/calibration_aruco_publisher.py
+++ b/scripts/calibration_aruco_publisher.py
@@ -37,7 +37,7 @@ class CalibrationArucoPublisher(Node):
 
         t = TransformStamped()
         t.header.stamp = self.get_clock().now().to_msg()
-        t.header.frame_id = "/camera_color_frame"
+        t.header.frame_id = "/camera_color_optical_frame"
         t.child_frame_id = "/calibration_aruco"
 
         t.transform.translation.x = cal_marker_pose.position.x

--- a/scripts/calibration_aruco_publisher.py
+++ b/scripts/calibration_aruco_publisher.py
@@ -3,6 +3,7 @@ import rclpy
 from rclpy.node import Node
 
 from geometry_msgs.msg import TransformStamped
+from rclpy.node import ParameterType, ParameterDescriptor
 from ros2_aruco_interfaces.msg import ArucoMarkers
 from tf2_ros import TransformBroadcaster
 
@@ -14,6 +15,17 @@ class CalibrationArucoPublisher(Node):
 
     def __init__(self):
         super().__init__("calibration_aruco_publisher")
+
+        tracking_base_frame_p = self.declare_parameter(
+            'tracking_base_frame', 
+            descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING)
+        )
+        self.tracking_base_frame = tracking_base_frame_p.get_parameter_value().string_value
+        tracking_marker_frame_p = self.declare_parameter(
+            'tracking_marker_frame', 
+            descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING)
+        )
+        self.tracking_marker_frame = tracking_marker_frame_p.get_parameter_value().string_value
 
         # ID of the aruco marker mounted on the robot
         self.marker_id = self.declare_parameter(
@@ -37,8 +49,8 @@ class CalibrationArucoPublisher(Node):
 
         t = TransformStamped()
         t.header.stamp = self.get_clock().now().to_msg()
-        t.header.frame_id = "/camera_color_optical_frame"
-        t.child_frame_id = "/calibration_aruco"
+        t.header.frame_id = self.tracking_base_frame
+        t.child_frame_id = self.tracking_marker_frame
 
         t.transform.translation.x = cal_marker_pose.position.x
         t.transform.translation.y = cal_marker_pose.position.y

--- a/scripts/handeye_publisher.py
+++ b/scripts/handeye_publisher.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+import numpy as np
+import rclpy
+import tf2_ros
+from easy_handeye2.handeye_calibration import load_calibration
+from geometry_msgs.msg import Transform, TransformStamped
+from rclpy.node import Node
+from rclpy.time import Time
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import ParameterType, ParameterDescriptor
+from transforms3d.quaternions import quat2mat, mat2quat
+
+
+def transform_to_matrix(transform):
+    """Converts a Transform message to a 4x4 transformation matrix using transforms3d."""
+    # Extract translation
+    translation = np.array([transform.translation.x, transform.translation.y, transform.translation.z])
+    # Extract quaternion (note that transforms3d uses [w, x, y, z] order)
+    rotation = np.array([transform.rotation.w, transform.rotation.x, transform.rotation.y, transform.rotation.z])
+    # Convert quaternion to rotation matrix
+    rotation_matrix = quat2mat(rotation)
+    # Create the 4x4 transformation matrix
+    matrix = np.eye(4)
+    matrix[:3, :3] = rotation_matrix
+    matrix[:3, 3] = translation
+    return matrix
+
+
+def matrix_to_transform(matrix):
+    """Converts a 4x4 transformation matrix to a Transform message using transforms3d."""
+    # Extract rotation matrix and translation vector
+    rotation_matrix = matrix[:3, :3]
+    translation = matrix[:3, 3]
+    # Convert rotation matrix to quaternion
+    rotation = mat2quat(rotation_matrix)  # Returns [w, x, y, z]
+    # Create Transform message
+    transform = Transform()
+    transform.translation.x = translation[0]
+    transform.translation.y = translation[1]
+    transform.translation.z = translation[2]
+    transform.rotation.w = rotation[0]
+    transform.rotation.x = rotation[1]
+    transform.rotation.y = rotation[2]
+    transform.rotation.z = rotation[3]
+    return transform
+
+
+class HandeyePublisher(Node):
+    def __init__(self):
+        super().__init__('handeye_publisher')
+
+        self.declare_parameter('name', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
+        name = self.get_parameter('name').get_parameter_value().string_value
+
+        self.get_logger().info(f'Loading the calibration with name {name}')
+        self.calibration = load_calibration(name)
+        parameters = self.calibration.parameters
+
+        # ID of the aruco marker mounted on the robot
+        self.marker_id = self.declare_parameter(
+            "marker_id", 1).get_parameter_value().integer_value
+
+        if parameters.calibration_type == 'eye_in_hand':
+            orig = parameters.robot_effector_frame
+        else:
+            orig = parameters.robot_base_frame
+        dest = "camera_link" # parameters.tracking_base_frame
+
+        self.tf_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
+        self.broadcaster = tf2_ros.StaticTransformBroadcaster(self)
+
+        self.calibration_tf = TransformStamped()
+        self.calibration_tf.header.frame_id = orig
+        self.calibration_tf.child_frame_id = dest
+
+        self.compute_transform_timer = self.create_timer(0.1, self.compute_transform)
+
+    def compute_transform(self):
+        try:
+            color_to_link_tf = self.tf_buffer.lookup_transform(
+                target_frame="camera_color_optical_frame",
+                source_frame="camera_link",
+                time=Time()
+            )
+        except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException):
+            self.get_logger().error('Could not get transform from camera_color_optical_frame to camera_link')
+            return
+
+        base_to_color_mat = transform_to_matrix(self.calibration.transform)
+        color_to_link_mat = transform_to_matrix(color_to_link_tf.transform)
+        base_to_link_mat = np.dot(base_to_color_mat, color_to_link_mat)
+        self.calibration_tf.transform = matrix_to_transform(base_to_link_mat)
+        self.get_logger().info('Computed the robot base to camera transform')
+
+        self.compute_transform_timer.cancel()
+        self.publish_transform_timer = self.create_timer(0.1, self.publish_transform)
+
+    def publish_transform(self):
+        self.calibration_tf.header.stamp = self.get_clock().now().to_msg()
+        self.broadcaster.sendTransform(self.calibration_tf)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    handeye_publisher = HandeyePublisher()
+
+    try:
+        rclpy.spin(handeye_publisher)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        handeye_publisher.destroy_node()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Previous calibration results were decent but wasn't totally accurate, particular for the orientation. Turns out there was a few mistakes made in the transforms of various frames that contributed to errors.

This PR use `camera_color_optical_frame` for calibration, and use it to compute the `base_link` to `camera_link` transform and publish it for validation.

For `follow_aruco_marker.py`, don't flip the target pose, so now the script will simply move the end effector to 5cm below the aruco marker pose (in z direction)